### PR TITLE
fix: use window.setTimeout() instead of activeWindow.setTimeout()

### DIFF
--- a/src/ui/components/TrendChart.ts
+++ b/src/ui/components/TrendChart.ts
@@ -207,7 +207,7 @@ export function renderTrendChart(
 				);
 			});
 
-			window.setTimeout(() => onMetricChange(option.id), 170);
+			globalThis.setTimeout(() => onMetricChange(option.id), 170);
 		};
 	});
 

--- a/src/ui/components/TrendChart.ts
+++ b/src/ui/components/TrendChart.ts
@@ -207,7 +207,7 @@ export function renderTrendChart(
 				);
 			});
 
-			activeWindow.setTimeout(() => onMetricChange(option.id), 170);
+			window.setTimeout(() => onMetricChange(option.id), 170);
 		};
 	});
 


### PR DESCRIPTION
## Summary

- Replaces `activeWindow.setTimeout()` with `window.setTimeout()` in `src/ui/components/TrendChart.ts:210`
- Timer functions should use the standard `window` object per linting rules

## Test plan

- [ ] Verify the TrendChart metric change animation still works correctly after the fix
- [ ] Run the linter to confirm no more `activeWindow` timer warnings

Closes #27

https://claude.ai/code/session_016EJ7sCo5coPgK6FH8UN2qL

---
_Generated by [Claude Code](https://claude.ai/code/session_016EJ7sCo5coPgK6FH8UN2qL)_