### PR TITLE
feat: add GitHub artifact attestations for release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
 
 permissions:
     contents: write
+    id-token: write
+    attestations: write
 
 jobs:
     release:
@@ -23,6 +25,13 @@ jobs:
 
             - run: npm ci
             - run: npm run build
+
+            - name: Attest build provenance
+              uses: actions/attest-build-provenance@v2
+              with:
+                  subject-path: |
+                      main.js
+                      styles.css
 
             - name: Release
               env:


### PR DESCRIPTION
## Summary

- Adds `actions/attest-build-provenance@v2` step to the release workflow, attesting `main.js` and `styles.css` after the build
- Adds required `id-token: write` and `attestations: write` permissions to the workflow

This lets users cryptographically verify that release assets were built directly from this repository's source code.

## Test plan

- [ ] Trigger a release workflow run and confirm attestation step succeeds
- [ ] Verify the attestation is visible on the release assets page in GitHub

Closes #28

https://claude.ai/code/session_016EJ7sCo5coPgK6FH8UN2qL

---
_Generated by [Claude Code](https://claude.ai/code/session_016EJ7sCo5coPgK6FH8UN2qL)_